### PR TITLE
Add ag-grid table template

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,6 +29,7 @@
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
+              "./node_modules/ag-grid-community/dist/styles/ag-grid.css",
               "src/styles.scss"
             ],
             "scripts": []
@@ -95,6 +96,7 @@
             ],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
+              "./node_modules/ag-grid-community/dist/styles/ag-grid.css",
               "src/styles.scss"
             ],
             "scripts": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -2203,6 +2203,16 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
+    "ag-grid-angular": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/ag-grid-angular/-/ag-grid-angular-21.2.2.tgz",
+      "integrity": "sha512-cd6mYMLn0ah1guISN+4SQZ6OFTLosbfFweaIsGWeVWN8mIOZGBNIpOy+GkuAJH53lkpsMqGgo9CEeUmTh/RhNg=="
+    },
+    "ag-grid-community": {
+      "version": "21.2.2",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-21.2.2.tgz",
+      "integrity": "sha512-x8kQmynYM/7zoigs7wIe7DkK1TIlUP5N1TYrGPsK8vO2gN+rqOok9csGPy4YamggWTcSxpy7wji/Kcz/gUp8/w=="
+    },
     "agent-base": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@angular/platform-browser": "~8.2.7",
     "@angular/platform-browser-dynamic": "~8.2.7",
     "@angular/router": "~8.2.7",
+    "ag-grid-angular": "^21.2.2",
+    "ag-grid-community": "^21.2.2",
     "hammerjs": "^2.0.8",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,16 +1,19 @@
-import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
+import {NgModule} from '@angular/core';
+import {Routes, RouterModule} from '@angular/router';
 import {PredictionComponent} from './components/prediction/prediction.component';
+import {ExampleTableComponent} from './components/example-table/example-table.component';
 
 
 const routes: Routes = [
-  { path: '', redirectTo: '/prediction', pathMatch: 'full' },
-  { path: 'prediction', component: PredictionComponent },
-  { path: '**', redirectTo: '/prediction' }
+  {path: '', redirectTo: '/prediction', pathMatch: 'full'},
+  {path: 'prediction', component: PredictionComponent},
+  {path: 'table', component: ExampleTableComponent},
+  {path: '**', redirectTo: '/prediction'}
 ];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -17,7 +17,10 @@
         <mat-icon>calendar_today</mat-icon>
         Prediction
       </a>
-
+      <a mat-list-item routerLink="/table">
+        <mat-icon>calendar_today</mat-icon>
+        Table example
+      </a>
     </mat-nav-list>
   </mat-sidenav>
   <mat-sidenav-content class='no-bg'>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,11 +6,18 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {MatIconModule, MatListModule, MatSidenavModule, MatToolbarModule, MatButtonModule} from '@angular/material';
 import { PredictionComponent } from './components/prediction/prediction.component';
 import {HttpClientModule} from '@angular/common/http';
+import {AgGridModule} from 'ag-grid-angular';
+import { ExampleTableComponent } from './components/example-table/example-table.component';
+import { TableComponent } from './components/common/table/table.component';
+import { DateCellRendererComponent } from './components/common/cellRenderers/date-cell-renderer/date-cell-renderer.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    PredictionComponent
+    PredictionComponent,
+    ExampleTableComponent,
+    TableComponent,
+    DateCellRendererComponent
   ],
   imports: [
     BrowserModule,
@@ -21,7 +28,10 @@ import {HttpClientModule} from '@angular/common/http';
     MatSidenavModule,
     MatListModule,
     MatButtonModule,
-    HttpClientModule
+    HttpClientModule,
+    AgGridModule.withComponents([
+      DateCellRendererComponent
+    ])
   ],
   providers: [
 

--- a/src/app/components/common/cellRenderers/date-cell-renderer/date-cell-renderer.component.html
+++ b/src/app/components/common/cellRenderers/date-cell-renderer/date-cell-renderer.component.html
@@ -1,0 +1,1 @@
+<span>{{params | date}}</span>

--- a/src/app/components/common/cellRenderers/date-cell-renderer/date-cell-renderer.component.spec.ts
+++ b/src/app/components/common/cellRenderers/date-cell-renderer/date-cell-renderer.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DateCellRendererComponent } from './date-cell-renderer.component';
+
+describe('DateCellRendererComponent', () => {
+  let component: DateCellRendererComponent;
+  let fixture: ComponentFixture<DateCellRendererComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DateCellRendererComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DateCellRendererComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/common/cellRenderers/date-cell-renderer/date-cell-renderer.component.ts
+++ b/src/app/components/common/cellRenderers/date-cell-renderer/date-cell-renderer.component.ts
@@ -1,0 +1,24 @@
+import {Component, OnInit} from '@angular/core';
+import {ICellRendererAngularComp} from 'ag-grid-angular';
+import {ICellRendererParams} from 'ag-grid-community';
+
+@Component({
+  selector: 'app-date-cell-renderer',
+  templateUrl: './date-cell-renderer.component.html',
+  styleUrls: ['./date-cell-renderer.component.scss']
+})
+export class DateCellRendererComponent implements ICellRendererAngularComp {
+  public params: string;
+
+  constructor() {
+  }
+
+  agInit(params: ICellRendererParams): void {
+    this.params = params.value;
+  }
+
+  refresh(params: any): boolean {
+    return false;
+  }
+
+}

--- a/src/app/components/common/table/table.component.html
+++ b/src/app/components/common/table/table.component.html
@@ -1,0 +1,15 @@
+<ag-grid-angular
+    #agGridTable
+    [style.height]="height"
+    class="ag-theme-material table-with-margin"
+    (selectionChanged)="updateSelectedRow($event)"
+    [rowData]="rowData"
+    [animateRows]="true"
+    multiSortKey='ctrl'
+    [defaultColDef]="defaultColDef"
+    rowMultiSelectWithClick="true"
+    (gridReady)="gridReady()"
+    [getRowHeight]="getRowHeight"
+    (rowDoubleClicked)="dblClickHandler($event)"
+>
+</ag-grid-angular>

--- a/src/app/components/common/table/table.component.html
+++ b/src/app/components/common/table/table.component.html
@@ -11,5 +11,6 @@
     (gridReady)="gridReady()"
     [getRowHeight]="getRowHeight"
     (rowDoubleClicked)="dblClickHandler($event)"
+    [pagination]="true"
 >
 </ag-grid-angular>

--- a/src/app/components/common/table/table.component.scss
+++ b/src/app/components/common/table/table.component.scss
@@ -1,0 +1,4 @@
+.table-with-margin {
+  margin: 10px;
+  border: 1px solid lightgray;
+}

--- a/src/app/components/common/table/table.component.spec.ts
+++ b/src/app/components/common/table/table.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TableComponent } from './table.component';
+
+describe('TableComponent', () => {
+  let component: TableComponent;
+  let fixture: ComponentFixture<TableComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TableComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/common/table/table.component.ts
+++ b/src/app/components/common/table/table.component.ts
@@ -1,0 +1,56 @@
+import {Component, EventEmitter, Input, OnChanges, OnInit, Output, ViewChild} from '@angular/core';
+import {AgGridAngular} from 'ag-grid-angular';
+import {TableHeaders} from '../../../configuration/TableHeaders';
+
+@Component({
+  selector: 'app-table',
+  templateUrl: './table.component.html',
+  styleUrls: ['./table.component.scss']
+})
+export class TableComponent implements OnInit, OnChanges {
+  @Input() data: Array<any> = new Input();
+  @Input() height: string = new Input();
+  @Input() classType: string = new Input();
+  @Output() selectedRow: EventEmitter<any> = new EventEmitter<any>();
+  @Output() doubleClicked: EventEmitter<any> = new EventEmitter<any>();
+  @ViewChild('agGridTable', {static: false}) agGrid: AgGridAngular;
+  rowData = [];
+  getRowHeight: any;
+  initialized = false;
+  defaultColDef = {
+    filterParams: {
+      applyButton: true,
+      clearButton: true,
+      caseSensitive: false
+    },
+    sortable: true,
+    resizable: true,
+    filter: true
+  };
+
+  constructor() {
+  }
+
+  ngOnInit() {
+  }
+  gridReady(): void {
+    this.agGrid.api.setColumnDefs(TableHeaders.getColumnDefs(this.classType));
+    this.agGrid.api.setRowData(this.data);
+    this.agGrid.api.sizeColumnsToFit();
+    this.initialized = true;
+  }
+
+  updateSelectedRow(event) {
+    this.selectedRow.emit(this.agGrid.api.getSelectedRows());
+  }
+
+  ngOnChanges() {
+    if (this.initialized) {
+      this.agGrid.api.setRowData(this.data);
+    }
+  }
+
+  dblClickHandler(event: any) {
+    this.doubleClicked.emit(event);
+  }
+}

--- a/src/app/components/example-table/example-table.component.html
+++ b/src/app/components/example-table/example-table.component.html
@@ -1,0 +1,5 @@
+<app-table (doubleClicked)="log($event)"
+           (selectedRow)="log($event)"
+           [classType]="'firstType'"
+           [data]="tableData"
+           [height]="'400px'"></app-table>

--- a/src/app/components/example-table/example-table.component.spec.ts
+++ b/src/app/components/example-table/example-table.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExampleTableComponent } from './example-table.component';
+
+describe('ExampleTableComponent', () => {
+  let component: ExampleTableComponent;
+  let fixture: ComponentFixture<ExampleTableComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ExampleTableComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExampleTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/example-table/example-table.component.ts
+++ b/src/app/components/example-table/example-table.component.ts
@@ -1,0 +1,39 @@
+import {Component, OnInit} from '@angular/core';
+
+@Component({
+  selector: 'app-example-table',
+  templateUrl: './example-table.component.html',
+  styleUrls: ['./example-table.component.scss']
+})
+export class ExampleTableComponent implements OnInit {
+  tableData = [
+    {
+      ep_number: 308,
+      ep_number_season: 1,
+      ep_title: 'Back and to the Future',
+      ep_director: 'John Showalter',
+      ep_writer: 'Andrew Dabb',
+      ep_air_date: new Date('10/10/2019')
+    },
+    {
+      ep_number: 309,
+      ep_number_season: 2,
+      ep_title: 'Raising Hell',
+      ep_director: 'Robert Singer',
+      ep_writer: 'Brad Buckner & Eugenie Ross-Leming',
+      ep_air_date: new Date('10/17/2019')
+    },
+  ];
+
+  constructor() {
+  }
+
+  ngOnInit() {
+    // this.service.getTableData().subscribe(data => this.tableData = data);
+  }
+
+  log(a) {
+    console.log(a);
+  }
+
+}

--- a/src/app/configuration/TableHeaders.ts
+++ b/src/app/configuration/TableHeaders.ts
@@ -1,0 +1,21 @@
+import {AgGridColumn} from 'ag-grid-angular';
+import {ColDef} from 'ag-grid-community';
+import {DateCellRendererComponent} from '../components/common/cellRenderers/date-cell-renderer/date-cell-renderer.component';
+
+export class TableHeaders {
+  public static getColumnDefs(classType: string): Array<ColDef> {
+    switch (classType.toLowerCase()) {
+      case 'firsttype':
+        return [
+          {headerName: 'Episode Number', field: 'ep_number', filter: 'agNumberColumnFiler'},
+          {headerName: 'Number in Season', field: 'ep_number_season', filter: 'agNumberColumnFiler', pinned: true},
+          {headerName: 'Title', field: 'ep_title', filter: 'agTextColumnFiler'},
+          {headerName: 'Director', field: 'ep_director', filter: 'agTextColumnFilter'},
+          {headerName: 'Writer', field: 'ep_writer', filter: 'agTextColumnFilter'},
+          {headerName: 'Air Date', field: 'ep_air_date', filter: 'agDateColumnFilter', cellRendererFramework: DateCellRendererComponent},
+        ];
+      default:
+        return null;
+    }
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
+@import "~ag-grid-community/dist/styles/ag-theme-material.css";
 
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+html, body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: Roboto, "Helvetica Neue", sans-serif;
+}


### PR DESCRIPTION
This example allows to easily use a table anywhere in the app with filtering, sorting and pagination